### PR TITLE
Core/Movement: no longer blindy rely on ack messages to change moveme…

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25987,8 +25987,8 @@ bool Player::SetDisableGravity(bool disable, bool /*packetOnly = false*/, bool /
 
     if (IsMovedByClient() && IsInWorld())
         MovementPacketSender::SendMovementFlagChangeToMover(this, MOVEMENTFLAG_DISABLE_GRAVITY, disable);
-    else
-        Unit::SetDisableGravity(disable, false, false);
+
+    Unit::SetDisableGravity(disable, false, false);
 
     return true;
 }
@@ -26000,8 +26000,8 @@ bool Player::SetCanFly(bool enable, bool /*packetOnly = false*/)
 
     if (IsMovedByClient() && IsInWorld())
         MovementPacketSender::SendMovementFlagChangeToMover(this, MOVEMENTFLAG_CAN_FLY, enable);
-    else
-        Unit::SetCanFly(enable);
+
+    Unit::SetCanFly(enable);
 
     return true;
 }
@@ -26013,15 +26013,16 @@ bool Player::SetCanTransitionBetweenSwimAndFly(bool enable)
 
     if (IsMovedByClient() && IsInWorld())
         MovementPacketSender::SendMovementFlagChangeToMover(this, MOVEMENTFLAG2_CAN_SWIM_TO_FLY_TRANS, enable);
-    else
-        Unit::SetCanTransitionBetweenSwimAndFly(enable);
+
+    Unit::SetCanTransitionBetweenSwimAndFly(enable);
 
     return true;
 }
 
 void Player::SendMovementSetCollisionHeight(float height, UpdateCollisionHeightReason reason)
 {
-    MovementPacketSender::SendHeightChangeToMover(this, height, reason);
+    if (IsMovedByClient() && IsInWorld())
+        MovementPacketSender::SendHeightChangeToMover(this, height, reason);
 }
 
 void Player::ResetAchievements()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9075,9 +9075,13 @@ void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
     if (m_speed_rate[mtype] == rate)
         return;
 
+
     float newSpeedFlat = rate * (IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]);
     if (IsMovedByClient() && IsInWorld())
+    {
         MovementPacketSender::SendSpeedChangeToMover(this, mtype, newSpeedFlat);
+        SetSpeedRateReal(mtype, rate);
+    }
     else if (IsMovedByClient() && !IsInWorld()) // (1)
         SetSpeedRateReal(mtype, rate);
     else // <=> if(!IsMovedByPlayer())


### PR DESCRIPTION
…ntstatus values as the client can and will sometimes ignore packets such as when receiving movement packets while not being sent out via update object (changing maps via teleport)

**Changes proposed**:

- 
- 
- 

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
