### PR TITLE
Corrected some warnings with modules

### DIFF
--- a/src/server/scripts/Custom/DeathAnnouncer.cpp
+++ b/src/server/scripts/Custom/DeathAnnouncer.cpp
@@ -36,7 +36,6 @@ public:
             {
                 std::string plr = killed->GetName();
                 std::string creature_n = killer->GetName();
-                bool ingroup = killed->GetGroup();
                 std::string tag_colour = "7bbef7";
                 std::string plr_colour = "7bbef7";
                 std::string creature_colour = "ff0000";
@@ -52,7 +51,6 @@ public:
         {
             std::string plr = killed->GetName();
             std::string creature_n = killer->GetName();
-            bool ingroup = killed->GetGroup();
             std::string tag_colour = "7bbef7";
             std::string plr_colour = "7bbef7";
             std::string creature_colour = "ff0000";
@@ -67,7 +65,6 @@ public:
         {
             std::string plr = killed->GetName();
             std::string creature_n = killer->GetName();
-            bool ingroup = killed->GetGroup();
             std::string tag_colour = "7bbef7";
             std::string plr_colour = "7bbef7";
             std::string creature_colour = "ff0000";
@@ -87,7 +84,6 @@ public:
             {
                 std::string plr = killed->GetName();
                 std::string creature_n = killer->GetName();
-                bool ingroup = killed->GetGroup();
                 std::string tag_colour = "7bbef7";
                 std::string plr_colour = "7bbef7";
                 std::string creature_colour = "ff0000";

--- a/src/server/scripts/Custom/SaveOnLevelup.cpp
+++ b/src/server/scripts/Custom/SaveOnLevelup.cpp
@@ -15,7 +15,7 @@ class spp_save_on_levelup : public PlayerScript
 public:
     spp_save_on_levelup() : PlayerScript("spp_save_on_levelup") { };
 
-    void OnLevelChanged(Player* player, uint8 oldLevel)
+    void OnLevelChanged(Player* player, uint8 /*oldLevel*/)
     {
         if (sConfigMgr->GetBoolDefault("Save.On.LevelUp", true))
         {

--- a/src/server/scripts/Custom/SkipStarterModule.cpp
+++ b/src/server/scripts/Custom/SkipStarterModule.cpp
@@ -345,7 +345,7 @@ public:
             return true;
         }
 
-        bool OnGossipSelect(Player* player, Creature* _creature, uint32 /*sender*/, uint32 gossipListId)
+        bool OnGossipSelect(Player* player, Creature* /*_creature*/, uint32 /*sender*/, uint32 gossipListId)
         {
             int DKL = sConfigMgr->GetFloatDefault("Skip.Deathknight.Start.Level", 58);
             ClearGossipMenuFor(player);
@@ -504,7 +504,7 @@ public:
             return true;
         }
 
-        bool OnGossipSelect(Player* player, Creature* _creature, uint32 /*sender*/, uint32 gossipListId)
+        bool OnGossipSelect(Player* player, Creature* /*_creature*/, uint32 /*sender*/, uint32 gossipListId)
         {
             int GBL = sConfigMgr->GetFloatDefault("Skip.Goblin.Start.Level", 16);
             ClearGossipMenuFor(player);
@@ -621,7 +621,7 @@ public:
             return true;
         }
 
-        bool OnGossipSelect(Player* player, Creature* _creature, uint32 /*sender*/, uint32 gossipListId)
+        bool OnGossipSelect(Player* player, Creature* /*_creature*/, uint32 /*sender*/, uint32 gossipListId)
         {
             int WGL = sConfigMgr->GetFloatDefault("Skip.Worgen.Start.Level", 16);
             ClearGossipMenuFor(player);

--- a/src/server/scripts/Custom/Weekend2xp.cpp
+++ b/src/server/scripts/Custom/Weekend2xp.cpp
@@ -13,7 +13,7 @@ class XpWeekend : public PlayerScript
 {
 public:
     XpWeekend() : PlayerScript("XpWeekend") { }
-    void OnGiveXP(Player* player, uint32& amount, Unit* victim)override
+    void OnGiveXP(Player* /*player*/, uint32& amount, Unit* /*victim*/)override
     {
         if (sConfigMgr->GetBoolDefault("DoubleXP.Enable", true))
         {
@@ -27,7 +27,7 @@ public:
             }
         }
     }
-    void OnLogin(Player* player, bool firstLogin)
+    void OnLogin(Player* player, bool /*firstLogin*/)
     {
         if (sConfigMgr->GetBoolDefault("DoubleXP.Enable", true))
         {

--- a/src/server/scripts/Custom/solocraft.cpp
+++ b/src/server/scripts/Custom/solocraft.cpp
@@ -49,7 +49,7 @@ class SolocraftConfig : public WorldScript
 public:
     SolocraftConfig() : WorldScript("SolocraftConfig") {}
     // Load Configuration Settings
-    void OnConfigLoad(bool reload) override
+    void OnConfigLoad(bool /*reload*/) override
     {
         // Dungeon Base Level
         dungeons =


### PR DESCRIPTION
We had alot of local variable is initialized but not referenced and unused parameter warnings dealing with these modules. I went ahead and either removed the not referenced parameters and supressed the unused parameter.

**Changes proposed**:

- 
- 
- 

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

**Known issues and TODO list**:

- [ ] 
- [ ] 
